### PR TITLE
ci: Use GitHub Actions V3 due to Node12 deprecation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3'
       - name: Install


### PR DESCRIPTION
All annotated warning link to the official GitHub documentation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/